### PR TITLE
Fix for request uri to include trailing slash and query string.

### DIFF
--- a/src/SsrServiceProvider.php
+++ b/src/SsrServiceProvider.php
@@ -47,7 +47,7 @@ class SsrServiceProvider extends ServiceProvider
                 return $serverRenderer
                     ->enabled($this->app->config->get('ssr.enabled'))
                     ->debug($this->app->config->get('ssr.debug'))
-                    ->context('url', '/'.$this->app->request->path())
+                    ->context('url', $this->app->request->getRequestUri())
                     ->context($this->app->config->get('ssr.context'))
                     ->env($this->app->config->get('ssr.env'))
                     ->resolveEntryWith(new MixResolver($this->app->config->get('ssr.mix')));


### PR DESCRIPTION
Modified context url to get `getRequestUri` instead of `path` to keep query strings and prevent double trailing slash on home.