### PR TITLE
Laravel 5.8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/support": "5.5.*|5.6.*|5.7.*",
+        "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*",
         "spatie/server-side-rendering": "^0.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0|^7.0",
-        "orchestra/testbench": "~3.5|~3.6|~3.7"
+        "orchestra/testbench": "~3.5|~3.6|~3.7|~3.8"
     },
     "autoload": {
         "psr-4": {

--- a/tests/NodeTest.php
+++ b/tests/NodeTest.php
@@ -7,7 +7,7 @@ use Orchestra\Testbench\TestCase as Orchestra;
 
 class NodeTest extends Orchestra
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/V8Test.php
+++ b/tests/V8Test.php
@@ -8,7 +8,7 @@ use Orchestra\Testbench\TestCase as Orchestra;
 
 class V8Test extends Orchestra
 {
-    public function setUp()
+    public function setUp(): void
     {
         if (! extension_loaded('v8js')) {
             $this->markTestSkipped('The V8Js extension is not available.');


### PR DESCRIPTION
This updates the composer json to support Laravel 5.8.

Due to Orchestra testbench having the return type hints on their setup I've added them to test suite as well.

This has caused the php 7.0 tests to fail. Would you like me to bump the compatible php version to 7.1+?