### PR TITLE
add temp path env variable

### DIFF
--- a/config/ssr.php
+++ b/config/ssr.php
@@ -32,7 +32,7 @@ return [
      */
     'node' => [
         'node_path' => env('NODE_PATH', '/usr/local/bin/node'),
-        'temp_path' => storage_path('app/ssr'),
+        'temp_path' => env('SSR_TEMP_PATH', storage_path('app/ssr')),
     ],
 
     /*


### PR DESCRIPTION
In Laravel, all the other locations where laravel writes to disk are configured via env variables (such as `config('view.compiled')` being `VIEW_COMPILED_PATH` ) This is a needed configuration for serverless and other environments where the main app directory is non-writable