### PR TITLE
Add PHP 8.2 Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,6 +26,10 @@ jobs:
                         php: 7.4
                     -   laravel: 9.*
                         php: 7.3
+                    -   laravel: 7.*
+                        php: 8.2
+                    -   laravel: 6.*
+                        php: 8.2
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,15 +30,18 @@ jobs:
                         php: 8.2
                     -   laravel: 6.*
                         php: 8.2
+                    -   laravel: 8.*
+                        php: 8.2
+                        dependency-version: prefer-lowest
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v1
+                uses: actions/checkout@v3
 
             -   name: Cache dependencies
-                uses: actions/cache@v1
+                uses: actions/cache@v3
                 with:
                     path: ~/.composer/cache/files
                     key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: [8.0, 7.4, 7.3]
+                php: [8.2, 8.0, 7.4, 7.3]
                 laravel: [6.*, 7.*, 8.*, 9.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
@@ -48,7 +48,7 @@ jobs:
 
             -   name: Install dependencies
                 run: |
-                    composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+                    composer require "laravel/framework:${{ matrix.laravel }}" "nesbot/carbon:^2.63" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
                     composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
             -   name: Execute tests

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "spatie/server-side-rendering": "^0.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0|^9.0",
+        "phpunit/phpunit": "^9.0",
         "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0"
     },
     "autoload": {


### PR DESCRIPTION
## Summary

This PR adds PHP 8.2 to the tests workflow.


_id:php82-support/v1.0_