### PR TITLE
Use explicit nullable type

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,6 +1,6 @@
 <?php
 
-function ssr(string $entry = null)
+function ssr(?string $entry = null)
 {
     if (func_num_args() === 0) {
         return app('ssr');


### PR DESCRIPTION
Fixes deprecation notice in PHP 8.4